### PR TITLE
Refactor infrastructure tests into AAA pattern and add unit tests

### DIFF
--- a/IMS.Infrastructure/SQLServer/DAOs/CategoryDAO.cs
+++ b/IMS.Infrastructure/SQLServer/DAOs/CategoryDAO.cs
@@ -42,8 +42,8 @@ public static class CategoryMappings
         // Normalize: lowercase + trim + collapse multiple spaces
         return string.Join(
             " ",
-            name.Trim().ToLower().Split([' '], StringSplitOptions.RemoveEmptyEntries)
+            name.Trim().ToLower().Split(' ', StringSplitOptions.RemoveEmptyEntries)
         );
-        
+
     }
 }

--- a/IMS.Tests/Integration/Infrastructure/SQLServer/CategoryRepositoryTests.cs
+++ b/IMS.Tests/Integration/Infrastructure/SQLServer/CategoryRepositoryTests.cs
@@ -10,21 +10,23 @@ public class CategoryRepositoryTests
     [Fact]
     public async Task CreateAndGetByNameAsync_NormalizesName()
     {
+        // Arrange
         var options = new DbContextOptionsBuilder<IMSDBContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
             .Options;
 
         await using var context = new IMSDBContext(options);
         await context.Database.EnsureCreatedAsync();
-
         var repository = new CategoryRepository(context, NullLogger<CategoryRepository>.Instance);
-
         var category = Category.Create(Guid.NewGuid(), "  Electronics ").Value;
-        var createResult = await repository.CreateAsync(category);
-        Assert.True(createResult.IsSuccess);
-        await context.SaveChangesAsync();
 
+        // Act
+        var createResult = await repository.CreateAsync(category);
+        await context.SaveChangesAsync();
         var getResult = await repository.GetByNameAsync("ELECTRONICS");
+
+        // Assert
+        Assert.True(createResult.IsSuccess);
         Assert.True(getResult.IsSuccess);
         Assert.NotNull(getResult.Value);
         Assert.Equal(category.Id, getResult.Value!.Id);

--- a/IMS.Tests/Integration/Infrastructure/SQLServer/UnitOfWorkTests.cs
+++ b/IMS.Tests/Integration/Infrastructure/SQLServer/UnitOfWorkTests.cs
@@ -10,6 +10,7 @@ public class UnitOfWorkTests
     [Fact]
     public async Task SaveChangesAsync_PersistsData()
     {
+        // Arrange
         var dbName = Guid.NewGuid().ToString();
         var options = new DbContextOptionsBuilder<IMSDBContext>()
             .UseInMemoryDatabase(dbName)
@@ -27,7 +28,10 @@ public class UnitOfWorkTests
         var product = Product.Create(Guid.NewGuid(), "Phone", "001", null, 0.5, ProductStatus.InStock, category).Value;
         await unitOfWork.Products.CreateAsync(product);
 
+        // Act
         var saveResult = await unitOfWork.SaveChangesAsync();
+
+        // Assert
         Assert.True(saveResult.IsSuccess);
 
         await using var verifyContext = new IMSDBContext(

--- a/IMS.Tests/Unit/Infrastructure/SQLServer/CategoryMappingsTests.cs
+++ b/IMS.Tests/Unit/Infrastructure/SQLServer/CategoryMappingsTests.cs
@@ -1,0 +1,33 @@
+using IMS.Domain.Entities;
+using IMS.Infrastructure.SQLServer.DAOs;
+
+namespace IMS.Tests.Unit.Infrastructure.SQLServer;
+
+public class CategoryMappingsTests
+{
+    [Theory]
+    [InlineData("  Electronics ", "electronics")]
+    [InlineData(" home  appliances ", "home appliances")]
+    public void NormalizeName_ReturnsLowercaseTrimmed(string input, string expected)
+    {
+        // Act
+        var result = CategoryMappings.NormalizeName(input);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void ToDao_NormalizesCategoryName()
+    {
+        // Arrange
+        var category = Category.Create(Guid.NewGuid(), "  Electronics ").Value;
+
+        // Act
+        var dao = category.ToDao();
+
+        // Assert
+        Assert.Equal("electronics", dao.Name);
+    }
+}
+


### PR DESCRIPTION
## Summary
- refactor SQL Server integration tests into Arrange-Act-Assert style
- add unit tests for Category mappings
- fix Category name normalization to use explicit separator

## Testing
- `dotnet test IMS.Tests/IMS.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68bdf7880890832b933f9e0e6945abdd